### PR TITLE
Arreglado logo del menu lateral

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require bootstrap-sprockets
+//= require bootstrap/collapse
 //= require bootstrap/tooltip
 //= require bootstrap-datepicker/core
 //= require bootstrap-datepicker/locales/bootstrap-datepicker.es.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require bootstrap-sprockets
 //= require bootstrap/tooltip
 //= require bootstrap-datepicker/core
 //= require bootstrap-datepicker/locales/bootstrap-datepicker.es.js

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -2,6 +2,18 @@
 
 $lista_height:  60px;
 
+.barra {
+    z-index: 5000;
+    margin-bottom: 50px;
+    background-color: $brand_dark;
+    display: block;
+}
+
+.barra__text {
+  color: white;
+  text-align: center;
+}
+
 .navbar-nav {
   display: block;
   margin-left: auto;
@@ -101,7 +113,7 @@ li .menu__el.selected {
 
   .menu {
     margin: 0;
-    margin-top: -25px;
+    margin-top: 50px;
     width: 100%;
   }
 

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -26,7 +26,9 @@ $lista_height:  60px;
 
 .logo {
   padding: 5%;
+  margin: 0;
   width: 95%;
+  margin-bottom: -40px;
 }
 
 .menu__el {

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -90,9 +90,6 @@ li .menu__el.selected {
 
 @media only screen and (max-width: 767px) {
   .vista {
-    position:absolute;
-    top: 35%;
-    left:0;
     display: block;
     margin-left: auto;
     margin-right: auto;

--- a/app/assets/stylesheets/_listpeople.scss
+++ b/app/assets/stylesheets/_listpeople.scss
@@ -42,13 +42,10 @@
 
 	@media only screen and (max-width: 767px) {
 		.listpeople__tabla {
-			margin-top: 0px;
-
+			margin-top: -82px;
 		}
 
-		.listpeople__buscadores{
-			position: fixed;
-			left:0;
-			top: 72px;
+		.listpeople__buscadores {
+			margin-top: 50px;
 		}
 }

--- a/app/assets/stylesheets/_listpeople.scss
+++ b/app/assets/stylesheets/_listpeople.scss
@@ -41,9 +41,6 @@
 }
 
 	@media only screen and (max-width: 767px) {
-		.listpeople__tabla {
-			margin-top: -82px;
-		}
 
 		.listpeople__buscadores {
 			margin-top: 50px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,41 @@
 </head>
 <body>
   <!-- MENU LATERAL -->
+<nav class="navbar navbar-default barra navbar-fixed-top barra hidden-sm hidden-md hidden-lg">
+        <div class="container-fluid">
+          <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+              <span class="sr-only">Toggle navigation</span>
+              <span class="icon-bar" ></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="#"><span class="barra__text">Texto dinamico Aquí</span></a>
+          </div>
+          <div id="navbar" class="navbar-collapse collapse" aria-expanded="false" style="height: 1px;">
+            <ul class="nav navbar-nav menu">
+          
+              <li><a href="#" 
+        class="list-group-item menu__el col-xs-12 active"><span class="menu__el__text">PERSONAS</span></a>
+      </li>
+      
+      <li><a href="#" 
+        class="list-group-item menu__el col-xs-12 "><span class="menu__el__text">FAMILIAS</span></a>
+      </li>
+      
+      <li><a href="#" 
+        class="list-group-item menu__el col-xs-12 "><span class="menu__el__text">SERVICIOS</span></a>
+      </li>
+      
+      <li><a href="#" 
+        class="list-group-item menu__el  col-xs-12 "><span class="menu__el__text">INFORMES</span></a>
+      </li>
+            </ul>
+          </div><!--/.nav-collapse -->
+        </div><!--/.container-fluid -->
+      </nav>
 
-  <div class="list-group nav navbar-nav col-md-3 col-xs-12 col-sm-3">
+  <div class="list-group nav navbar-nav col-md-3 col-xs-12 col-sm-3 hidden-xs">
 
     <img class="logo hidden-xs" src="/assets/logo-menu.svg">
 


### PR DESCRIPTION
- Tenemos menu PRO en la versión móvil a falta de ponerle algún efecto chulo y retocarlo.
- Ahora tiene la misma separación por arriba y por abajo el logo del menu lateral.
- Mejor integración del menu móvil con el contenido dinámico.
